### PR TITLE
调整文件的大小计算和写入方法

### DIFF
--- a/main.py
+++ b/main.py
@@ -51,9 +51,13 @@ async def delete_expire_files():
         async with AsyncSession(engine, expire_on_commit=False) as s:
             query = select(Codes).where(or_(Codes.exp_time < datetime.datetime.now(), Codes.count == 0))
             exps = (await s.execute(query)).scalars().all()
-            files = [{'type': old.type, 'text': old.text} for old in exps]
+            files = []
+            exps_ids = []
+            for exp in exps:
+                if exp.type != "text":
+                    files.append(exp.text)
+                exps_ids.append(exp.id)
             await storage.delete_files(files)
-            exps_ids = [exp.id for exp in exps]
             query = delete(Codes).where(Codes.id.in_(exps_ids))
             await s.execute(query)
             await s.commit()
@@ -83,9 +87,11 @@ async def admin_post(s: AsyncSession = Depends(get_session)):
 async def admin_delete(code: str, s: AsyncSession = Depends(get_session)):
     query = select(Codes).where(Codes.code == code)
     file = (await s.execute(query)).scalars().first()
-    await storage.delete_file({'type': file.type, 'text': file.text})
-    await s.delete(file)
-    await s.commit()
+    if file:
+        if file.type != 'text':
+            await storage.delete_file(file.text)
+        await s.delete(file)
+        await s.commit()
     return {'detail': '删除成功'}
 
 
@@ -115,7 +121,8 @@ async def index(code: str, ip: str = Depends(ip_limit), s: AsyncSession = Depend
         error_count = settings.ERROR_COUNT - ip_limit.add_ip(ip)
         raise HTTPException(status_code=404, detail=f"取件码错误，错误{error_count}次将被禁止10分钟")
     if info.exp_time < datetime.datetime.now() or info.count == 0:
-        await storage.delete_file({'type': info.type, 'text': info.text})
+        if info.type != "text":
+            await storage.delete_file(info.text)
         await s.delete(info)
         await s.commit()
         raise HTTPException(status_code=404, detail="取件码已过期，请联系寄件人")

--- a/storage.py
+++ b/storage.py
@@ -46,16 +46,13 @@ class FileSystemStorage:
         filepath = await self.get_filepath(text)
         await asyncio.to_thread(self._save, filepath, file.file)
 
-    async def delete_file(self, file):
-        # 是文件就删除
-        if file['type'] != 'text':
-            filepath = self.DATA_ROOT / file['text'].lstrip(self.STATIC_URL + '/')
-            await asyncio.to_thread(os.remove, filepath)
+    async def delete_file(self, text: str):
+        filepath = await self.get_filepath(text)
+        await asyncio.to_thread(os.remove, filepath)
 
-    async def delete_files(self, files):
-        for file in files:
-            if file['type'] != 'text':
-                await self.delete_file(file)
+    async def delete_files(self, texts):
+        tasks = [self.delete_file(text) for text in texts]
+        await asyncio.gather(*tasks)
 
 
 STORAGE_ENGINE = {

--- a/storage.py
+++ b/storage.py
@@ -1,7 +1,10 @@
 import os
 import asyncio
-import datetime
+from datetime import datetime
 from pathlib import Path
+from typing import BinaryIO
+
+from fastapi import UploadFile
 
 import settings
 
@@ -11,24 +14,37 @@ class FileSystemStorage:
     STATIC_URL = settings.STATIC_URL
     NAME = "filesystem"
 
-    async def get_filepath(self, path):
-        return self.DATA_ROOT / path.lstrip(self.STATIC_URL + '/')
+    async def get_filepath(self, text: str):
+        return self.DATA_ROOT / text.lstrip(self.STATIC_URL + '/')
 
-    def _save(self, filepath, file_bytes):
-        with open(filepath, 'wb') as f:
-            f.write(file_bytes)
-
-    async def save_file(self, file, file_bytes, key):
-        now = datetime.datetime.now()
-        path = self.DATA_ROOT / f"upload/{now.year}/{now.month}/{now.day}/"
+    async def get_text(self, file: UploadFile, key: str):
         ext = file.filename.split('.')[-1]
-        name = f'{key}.{ext}'
+        now = datetime.now()
+        path = self.DATA_ROOT / f"upload/{now.year}/{now.month}/{now.day}/"
         if not path.exists():
             path.mkdir(parents=True)
-        filepath = path / name
-        await asyncio.to_thread(self._save, filepath, file_bytes)
+        filepath = path / f'{key}.{ext}'
         text = f"{self.STATIC_URL}/{filepath.relative_to(self.DATA_ROOT)}"
         return text
+
+    async def get_size(self, file: UploadFile):
+        f = file.file
+        f.seek(0, os.SEEK_END)
+        size = f.tell()
+        f.seek(0, os.SEEK_SET)
+        return size
+
+    def _save(self, filepath, file: BinaryIO):
+        with open(filepath, 'wb') as f:
+            chunk_size = 256 * 1024
+            chunk = file.read(chunk_size)
+            while chunk:
+                f.write(chunk)
+                chunk = file.read(chunk_size)
+
+    async def save_file(self, file: UploadFile, text: str):
+        filepath = await self.get_filepath(text)
+        await asyncio.to_thread(self._save, filepath, file.file)
 
     async def delete_file(self, file):
         # 是文件就删除


### PR DESCRIPTION
计算文件大小避免读取整个文件，防止大文件爆内存。

文件分块写入，并且放到后台任务执行，加快请求响应速度。