### PR TITLE
fix: 修改文件存放路径的拼接方式

### DIFF
--- a/storage.py
+++ b/storage.py
@@ -85,7 +85,7 @@ class FileSystemStorage:
         currpath = os.path.dirname(filepath)
         if os.listdir(currpath):
             return
-        while str(currpath) != (str(self.DATA_ROOT) + '\\upload'):
+        while str(currpath) != (str(os.path.join(self.DATA_ROOT, 'upload'))):
             if not os.listdir(currpath):
                 os.rmdir(os.path.abspath(currpath))
             currpath = os.path.dirname(currpath)


### PR DESCRIPTION
由于编写的时候只测试了基于Windows下的运行效果，没有注意Linux下的路径问题，导致在Linux下使用会导致由于路径格式格式不同引发错误，因此使用`os.path.join()`方法对文件的存放路径进行拼接