### PR TITLE
feat: 文件箱标题区分收件箱和发件箱

### DIFF
--- a/fcb-fronted/src/components/FileBox.vue
+++ b/fcb-fronted/src/components/FileBox.vue
@@ -70,7 +70,8 @@ function getQrCodeUrl(code: string) {
   <el-drawer :append-to-body="true" v-model="fileBoxStore.showFileBox" direction="btt" style="max-width: 1080px;margin: auto;"
              size="400">
     <template #header>
-      <h4>{{t('fileBox.fileBox')}}</h4>
+      <h4 v-if="route.name=='home'">{{t('fileBox.receiveFileBox')}}</h4>
+      <h4 v-else>{{t('fileBox.sendFileBox')}}</h4>
     </template>
     <template #default>
       <div v-if="route.name=='home'" style="display: flex;flex-wrap: wrap;justify-content: center">

--- a/fcb-fronted/src/locals/en.ts
+++ b/fcb-fronted/src/locals/en.ts
@@ -31,7 +31,8 @@ export default {
   fileBox: {
     copySuccess: 'Copied successfully',
     inputNotEmpty: 'Please enter the five-digit pickup code',
-    fileBox: 'File Box',
+    sendFileBox: 'Send File Box',
+    receiveFileBox: 'Receive File Box',
     textDetail: 'Text Detail',
     copy: 'Copy',
     close: 'Close',

--- a/fcb-fronted/src/locals/zh.ts
+++ b/fcb-fronted/src/locals/zh.ts
@@ -31,7 +31,8 @@ export default {
   fileBox: {
     copySuccess: '复制成功',
     inputNotEmpty: '请输入五位取件码',
-    fileBox: '文件箱',
+    sendFileBox: '发件箱',
+    receiveFileBox: '收件箱',
     textDetail: '文本详情',
     copy: '复 制',
     close: '关 闭',


### PR DESCRIPTION
问题：
FileBox组件根据数据类型的不同渲染了不同的列表，而没有明确告诉用户当前渲染的是哪个列表，导致刚上手的用户不能很好的分辨出当前是接受的列表还是发送的列表。

调整：
1. 在 `zh.ts` 中添加 `sendFileBox: '发件箱'` 与 `receiveFileBox: '收件箱'`，并在 `en.ts` 中添加英文翻译
2. 在 `FileBox.vue` 中对 `route.name` 进行判断，如果为 `home` 渲染为收件箱，否则渲染为发件箱