### PR TITLE
fix(base): 修复文件名中的中文编码问题

### DIFF
--- a/apps/base/utils.py
+++ b/apps/base/utils.py
@@ -2,6 +2,7 @@ import datetime
 import hashlib
 import os
 import uuid
+from urllib.parse import unquote
 
 from fastapi import UploadFile, HTTPException
 from typing import Optional, Tuple
@@ -17,7 +18,8 @@ async def get_file_path_name(file: UploadFile) -> Tuple[str, str, str, str, str]
     today = datetime.datetime.now()
     storage_path = settings.storage_path.strip("/")  # 移除开头和结尾的斜杠
     file_uuid = uuid.uuid4().hex
-    filename = await sanitize_filename(file.filename)
+    # 一些客户端对非ASCII字符会进行编码，需要解码
+    filename = await sanitize_filename(unquote(file.filename))
     # 使用 UUID 作为子目录名
     base_path = f"share/data/{today.strftime('%Y/%m/%d')}/{file_uuid}"
 


### PR DESCRIPTION
- 在 sanitize_filename 函数中添加 unquote 导入并使用其解码文件名
- 这个修改解决了非 ASCII 字符在文件名中显示为编码形式的问题
- Non-ASCll filename uploads don't comply with RFC 7578
- 例如 aiohttp 上传文件
<img width="270" alt="Snipaste_2025-06-20_15-44-12" src="https://github.com/user-attachments/assets/4580b489-e7d6-4e36-81b6-05b38c130c20" />
