### PR TITLE
Fix: increase default timeout in docker-compose example to support large file transfers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,11 +2,17 @@ version: "3"
 services:
   file-code-box:
     image: lanol/filecodebox:latest
+    container_name: filecodebox
     volumes:
       - fcb-data:/app/data:rw
     restart: unless-stopped
     ports:
       - "12345:12345"
+    command: >
+      gunicorn -k uvicorn.workers.UvicornWorker main:app
+      --bind 0.0.0.0:12345
+      --timeout 600
+      --workers 2
 volumes:
   fcb-data:
     external: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ version: "3"
 services:
   file-code-box:
     image: lanol/filecodebox:latest
-    container_name: filecodebox
     volumes:
       - fcb-data:/app/data:rw
     restart: unless-stopped


### PR DESCRIPTION
This PR updates the docker-compose.yml example by overriding the default start command with Gunicorn parameters.
Increased --timeout from the default 30s to 600s to avoid API timeout when uploading or downloading large files.
Added --workers 2 for better concurrency.
This change helps users who encounter the “30s API timeout” issue (#408) when deploying with Docker.