### PR TITLE
优化启用下载代理

### DIFF
--- a/core/storage.py
+++ b/core/storage.py
@@ -354,8 +354,9 @@ class S3FileStorage(FileStorageInterface):
                             yield chunk
             
             from fastapi.responses import StreamingResponse
+            encoded_filename = quote(filename, safe='')
             headers = {
-                "Content-Disposition": f'attachment; filename="{filename.encode("utf-8").decode("latin-1")}"',
+                "Content-Disposition": f"attachment; filename*=UTF-8''{encoded_filename}",
                 "Content-Length": str(content_length)
             }
             return StreamingResponse(
@@ -671,8 +672,9 @@ class OneDriveFileStorage(FileStorageInterface):
                                 break
                             yield chunk
             
+            encoded_filename = quote(filename, safe='')
             headers = {
-                "Content-Disposition": f'attachment; filename="{filename.encode("utf-8").decode("latin-1")}"',
+                "Content-Disposition": f"attachment; filename*=UTF-8''{encoded_filename}",
                 "Content-Length": str(content_length)
             }
             return StreamingResponse(
@@ -862,8 +864,9 @@ class OpenDALFileStorage(FileStorageInterface):
             except AttributeError:
                 # 如果 reader 方法不存在，回退到全量读取（兼容旧版本）
                 content = await self.operator.read(await file_code.get_file_path())
+                encoded_filename = quote(filename, safe='')
                 headers = {
-                    "Content-Disposition": f'attachment; filename="{filename}"',
+                    "Content-Disposition": f"attachment; filename*=UTF-8''{encoded_filename}",
                     "Content-Length": str(content_length)
                 }
                 return Response(
@@ -878,8 +881,9 @@ class OpenDALFileStorage(FileStorageInterface):
                         break
                     yield chunk
             
+            encoded_filename = quote(filename, safe='')
             headers = {
-                "Content-Disposition": f'attachment; filename="{filename}"',
+                "Content-Disposition": f"attachment; filename*=UTF-8''{encoded_filename}",
                 "Content-Length": str(content_length)
             }
             return StreamingResponse(
@@ -1105,8 +1109,9 @@ class WebDAVFileStorage(FileStorageInterface):
                                 break
                             yield chunk
             
+            encoded_filename = quote(filename, safe='')
             headers = {
-                "Content-Disposition": f'attachment; filename="{filename.encode("utf-8").decode()}"',
+                "Content-Disposition": f"attachment; filename*=UTF-8''{encoded_filename}",
                 "Content-Length": str(content_length)
             }
             return StreamingResponse(

--- a/core/storage.py
+++ b/core/storage.py
@@ -147,7 +147,7 @@ class SystemFileStorage(FileStorageInterface):
         return FileResponse(
             file_path,
             media_type="application/octet-stream",
-            headers={"Content-Disposition": content_disposition},
+            headers={"Content-Disposition": content_disposition, "Content-Length": str(file_code.size)},
             filename=filename  # 保留原始文件名以备某些场景使用
         )
 
@@ -329,7 +329,8 @@ class S3FileStorage(FileStorageInterface):
             
             from fastapi.responses import StreamingResponse
             headers = {
-                "Content-Disposition": f'attachment; filename="{filename.encode("utf-8").decode("latin-1")}"'
+                "Content-Disposition": f'attachment; filename="{filename.encode("utf-8").decode("latin-1")}"',
+                "Content-Length": str(file_code.size)
             }
             return StreamingResponse(
                 stream_generator(),
@@ -633,7 +634,8 @@ class OneDriveFileStorage(FileStorageInterface):
                             yield chunk
             
             headers = {
-                "Content-Disposition": f'attachment; filename="{filename.encode("utf-8").decode("latin-1")}"'
+                "Content-Disposition": f'attachment; filename="{filename.encode("utf-8").decode("latin-1")}"',
+                "Content-Length": str(file_code.size)
             }
             return StreamingResponse(
                 stream_generator(),
@@ -810,7 +812,8 @@ class OpenDALFileStorage(FileStorageInterface):
                 # 如果 reader 方法不存在，回退到全量读取（兼容旧版本）
                 content = await self.operator.read(await file_code.get_file_path())
                 headers = {
-                    "Content-Disposition": f'attachment; filename="{filename}"'
+                    "Content-Disposition": f'attachment; filename="{filename}"',
+                    "Content-Length": str(file_code.size)
                 }
                 return Response(
                     content, headers=headers, media_type="application/octet-stream"
@@ -825,7 +828,8 @@ class OpenDALFileStorage(FileStorageInterface):
                     yield chunk
             
             headers = {
-                "Content-Disposition": f'attachment; filename="{filename}"'
+                "Content-Disposition": f'attachment; filename="{filename}"',
+                "Content-Length": str(file_code.size)
             }
             return StreamingResponse(
                 stream_generator(),
@@ -1038,7 +1042,8 @@ class WebDAVFileStorage(FileStorageInterface):
                             yield chunk
             
             headers = {
-                "Content-Disposition": f'attachment; filename="{filename.encode("utf-8").decode()}"'
+                "Content-Disposition": f'attachment; filename="{filename.encode("utf-8").decode()}"',
+                "Content-Length": str(file_code.size)
             }
             return StreamingResponse(
                 stream_generator(),


### PR DESCRIPTION
我这边有大文件加载需要用下载代理的需求。
之前代码不能支持大文件下载。所以处理了一下关于大文件中转的一些问题。

我这里只有S3环境可以测试。我目前自测是没有什么问题。关于onedrive 和 webdav没有做此类测试。 