### PR TITLE
[Security] 安全漏洞修复合集（6项 Critical/High）

### DIFF
--- a/apps/base/quota.py
+++ b/apps/base/quota.py
@@ -8,6 +8,20 @@ from core.settings import settings
 from core.utils import get_now
 
 
+def _sql_placeholders(count: int) -> list[str]:
+    """根据数据库类型生成参数占位符（多数据库兼容）。
+
+    SQLite 用 ?，PostgreSQL 用 $1/$2/...，MySQL 用 %s。
+    """
+    conn = connections.get("default")
+    engine = getattr(conn, "engine", "") or ""
+    if "postgres" in engine:
+        return [f"${i}" for i in range(1, count + 1)]
+    if "mysql" in engine:
+        return ["%s"] * count
+    return ["?"] * count
+
+
 def get_storage_limit() -> int:
     try:
         return max(0, int(getattr(settings, "storageLimit", 0)))
@@ -49,15 +63,16 @@ async def reserve_storage(token: str, size: int, ttl_seconds: int) -> None:
         raise HTTPException(status_code=409, detail="上传容量预留信息不一致")
 
     try:
+        ph = _sql_placeholders(6)
         affected, _ = await conn.execute_query(
-            """
+            f"""
             INSERT INTO storagereservation (token, size, expires_at)
-            SELECT ?, ?, ?
+            SELECT {ph[0]}, {ph[1]}, {ph[2]}
             WHERE (
                 COALESCE((SELECT SUM(size) FROM filecodes), 0)
-                + COALESCE((SELECT SUM(size) FROM storagereservation WHERE expires_at > ?), 0)
-                + ?
-            ) <= ?
+                + COALESCE((SELECT SUM(size) FROM storagereservation WHERE expires_at > {ph[3]}), 0)
+                + {ph[4]}
+            ) <= {ph[5]}
             """,
             [token, requested_size, expires_at, now, requested_size, limit],
         )

--- a/apps/base/views.py
+++ b/apps/base/views.py
@@ -152,6 +152,9 @@ async def share_text(
     expire_style: str = Form(default="day"),
     ip: str = Depends(ip_limit["upload"]),
 ):
+    # 修复: 与 share_file 保持一致，校验过期方式是否在管理员允许的白名单内
+    if expire_style not in settings.expireStyle:
+        raise HTTPException(status_code=400, detail="过期时间类型错误")
     text_size = len(text.encode("utf-8"))
     max_txt_size = 222 * 1024
     if text_size > max_txt_size:
@@ -374,7 +377,9 @@ async def select_file(data: SelectFileModel, ip: str = Depends(ip_limit["error"]
 async def download_file(key: str, code: str, ip: str = Depends(ip_limit["error"])):
     file_storage: FileStorageInterface = storages[settings.file_storage]()
     normalized_code = normalize_share_code(code)
-    if await get_select_token(normalized_code) != key:
+    # 修复: 同时校验当前窗口与上一个窗口的 token，修复时间窗口边界竞态
+    valid_keys = [await get_select_token(normalized_code, offset=i) for i in range(2)]
+    if key not in valid_keys:
         ip_limit["error"].add_ip(ip)
         raise HTTPException(status_code=403, detail="下载鉴权失败")
     has, file_code = await get_code_file_by_code(normalized_code)
@@ -659,6 +664,9 @@ async def complete_upload(
     chunk_info = await UploadChunk.filter(upload_id=upload_id, chunk_index=-1).first()
     if not chunk_info:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="上传会话不存在")
+    # 修复: 与 share_file 保持一致，校验过期方式是否在管理员允许的白名单内
+    if data.expire_style not in settings.expireStyle:
+        raise HTTPException(status_code=400, detail="过期时间类型错误")
     await reserve_storage(
         f"chunk:{upload_id}",
         chunk_info.file_size,

--- a/core/storage.py
+++ b/core/storage.py
@@ -25,6 +25,7 @@ from core.settings import data_root, settings
 from apps.base.models import FileCodes, UploadChunk
 from core.utils import get_file_url, sanitize_filename
 from fastapi.responses import FileResponse, StreamingResponse
+from starlette.background import BackgroundTask
 
 
 class FileStorageInterface:
@@ -395,7 +396,8 @@ class S3FileStorage(FileStorageInterface):
             return StreamingResponse(
                 stream_generator(),
                 media_type="application/octet-stream",
-                headers=headers
+                headers=headers,
+                background=BackgroundTask(session.close),  # 修复: 客户端中断时兖底关闭会话
             )
         except HTTPException:
             raise
@@ -733,7 +735,8 @@ class OneDriveFileStorage(FileStorageInterface):
             return StreamingResponse(
                 stream_generator(),
                 media_type="application/octet-stream",
-                headers=headers
+                headers=headers,
+                background=BackgroundTask(session.close),  # 修复: 客户端中断时兖底关闭会话
             )
         except HTTPException:
             raise
@@ -1209,7 +1212,8 @@ class WebDAVFileStorage(FileStorageInterface):
             return StreamingResponse(
                 stream_generator(),
                 media_type="application/octet-stream",
-                headers=headers
+                headers=headers,
+                background=BackgroundTask(session.close),  # 修复: 客户端中断时兖底关闭会话
             )
         except aiohttp.ClientError as e:
             raise HTTPException(

--- a/core/utils.py
+++ b/core/utils.py
@@ -41,17 +41,21 @@ async def get_now():
     return datetime.datetime.now(datetime.timezone(datetime.timedelta(hours=8)))
 
 
-async def get_select_token(code: str):
+async def get_select_token(code: str, offset: int = 0):
     """
     获取下载token
-    :param code:
+    :param code: 取件码
+    :param offset: 时间窗口偏移（0=当前窗口，1=上一个窗口）。
+        用于兼容窗口边界竞态：用户在某窗口末尾获取的 token，
+        请求到达服务器时可能已进入下一窗口。
     :return:
     """
     token = getattr(settings, "jwt_secret", "")
     if not token:
         raise RuntimeError("应用签名密钥未初始化")
+    time_factor = int(time.time() / 1000) - offset
     return hashlib.sha256(
-        f"{code}{int(time.time() / 1000)}000{token}".encode()
+        f"{code}{time_factor}000{token}".encode()
     ).hexdigest()
 
 

--- a/main.py
+++ b/main.py
@@ -767,7 +767,9 @@ async def refresh_settings_middleware(request, call_next):
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
-    allow_credentials=True,
+    # 修复: 前后端同源部署且使用 Bearer Token 认证（非 Cookie），
+    # allow_origins=["*"] 与 allow_credentials=True 同开是危险且违规的组合，故关闭 credentials。
+    allow_credentials=False,
     allow_methods=["*"],
     allow_headers=["*"],
 )


### PR DESCRIPTION
对 FileCodeBox 进行代码审计后，发现并修复了以下安全问题。所有修复向后兼容，不影响现有功能。

## 修复清单

### 🔴 Critical（3项）
- **SEC-002**: share_text 缺少 expire_style 白名单校验，可绕过管理员过期策略
- **SEC-003**: complete_upload 同样缺少校验
- **SEC-004**: CORS allow_origins=["*"] + allow_credentials=True 冲突（同源部署无需凭证跨域）

### 🟠 High（3项）
- **BUG-001**: quota.py SQL 写死 ? 占位符，PostgreSQL/MySQL 下配额功能静默失效
- **BUG-002**: 下载 Token 时间窗口边界竞态，窗口末尾获取的 Token 偶发失效
- **BUG-003**: S3/OneDrive/WebDAV 下载时客户端中断后 aiohttp session 未关闭，连接泄漏

## 兼容性
- ✅ 不改变任何 API 接口签名
- ✅ 不影响现有配置
- ✅ 支持 SQLite / PostgreSQL / MySQL
- ✅ 兼容 CLI（curl/wget）操作