### PR TITLE
fix: magic-byte file checks, admin login rate limit, non-root Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,14 @@ RUN apt-get update \
  && apt-get upgrade -y --no-install-recommends \
  && rm -rf /var/lib/apt/lists/* \
  && pip install --no-cache-dir -r requirements.txt \
- && pip cache purge || true
+ && pip cache purge || true \
+ && groupadd --system --gid 1000 appuser \
+ && useradd --system --uid 1000 --gid appuser --create-home --home-dir /home/appuser --shell /usr/sbin/nologin appuser \
+ && mkdir -p /app/data \
+ && chown -R appuser:appuser /app
+
+# 非 root 运行，降低容器逃逸后的主机影响面
+USER appuser
 
 # 环境变量配置
 ENV HOST="0.0.0.0" \

--- a/apps/admin/services.py
+++ b/apps/admin/services.py
@@ -1518,6 +1518,8 @@ class ConfigService:
         "enableChunk",
         "errorCount",
         "errorMinute",
+        "loginCount",
+        "loginMinute",
         "max_save_seconds",
         "onedrive_proxy",
         "openUpload",

--- a/apps/admin/views.py
+++ b/apps/admin/views.py
@@ -38,6 +38,7 @@ from apps.admin.dependencies import (
 )
 from core.settings import settings
 from core.utils import get_now, verify_password
+from apps.base.utils import ip_limit
 
 admin_api = APIRouter(
     prefix="/admin", tags=["管理"], dependencies=[Depends(admin_required)]
@@ -53,8 +54,10 @@ def _pick_query_text(*values: Optional[str]) -> Optional[str]:
 
 
 @admin_api.post("/login")
-async def login(data: LoginData):
+async def login(data: LoginData, ip: str = Depends(ip_limit["login"])):
+    # 登录失败计入 IP 频率限制，超过 loginCount/loginMinute 后暂时锁定
     if not verify_password(data.password, settings.admin_token):
+        ip_limit["login"].add_ip(ip)
         raise HTTPException(status_code=401, detail="密码错误")
 
     expires_in = get_admin_session_expire_seconds()

--- a/apps/base/file_validation.py
+++ b/apps/base/file_validation.py
@@ -1,0 +1,196 @@
+"""文件类型校验：扩展名 / MIME 白名单 + magic bytes 防伪造。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from fastapi import HTTPException, UploadFile
+from fnmatch import fnmatchcase
+
+from core.settings import settings
+
+
+@dataclass(frozen=True)
+class FileKind:
+    name: str
+    extensions: tuple[str, ...]
+    mimes: tuple[str, ...]
+    signatures: tuple[bytes, ...]
+
+
+FILE_KINDS: tuple[FileKind, ...] = (
+    FileKind("png", (".png",), ("image/png",), (b"\x89PNG\r\n\x1a\n",)),
+    FileKind("jpg", (".jpg", ".jpeg"), ("image/jpeg",), (b"\xff\xd8\xff",)),
+    FileKind("gif", (".gif",), ("image/gif",), (b"GIF87a", b"GIF89a")),
+    FileKind("webp", (".webp",), ("image/webp",), ()),
+    FileKind("bmp", (".bmp",), ("image/bmp", "image/x-ms-bmp"), (b"BM",)),
+    FileKind("pdf", (".pdf",), ("application/pdf",), (b"%PDF",)),
+    FileKind(
+        "zip",
+        (".zip", ".docx", ".xlsx", ".pptx", ".apk", ".jar"),
+        (
+            "application/zip",
+            "application/x-zip-compressed",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            "application/java-archive",
+            "application/vnd.android.package-archive",
+        ),
+        (b"PK\x03\x04", b"PK\x05\x06", b"PK\x07\x08"),
+    ),
+    FileKind(
+        "rar",
+        (".rar",),
+        ("application/x-rar-compressed", "application/vnd.rar"),
+        (b"Rar!\x1a\x07\x00", b"Rar!\x1a\x07\x01\x00"),
+    ),
+    FileKind("7z", (".7z",), ("application/x-7z-compressed",), (b"7z\xbc\xaf'\x1c",)),
+    FileKind("gz", (".gz", ".tgz"), ("application/gzip", "application/x-gzip"), (b"\x1f\x8b",)),
+    FileKind(
+        "mp3",
+        (".mp3",),
+        ("audio/mpeg",),
+        (b"ID3", b"\xff\xfb", b"\xff\xf3", b"\xff\xf2"),
+    ),
+    FileKind("mp4", (".mp4", ".m4a", ".mov"), ("video/mp4", "audio/mp4", "video/quicktime"), ()),
+    FileKind(
+        "exe",
+        (".exe", ".dll", ".sys"),
+        ("application/x-msdownload", "application/x-dosexec"),
+        (b"MZ",),
+    ),
+    FileKind("elf", (".elf", ".so", ".o"), ("application/x-executable",), (b"\x7fELF",)),
+)
+
+KNOWN_EXTENSIONS = {ext for kind in FILE_KINDS for ext in kind.extensions}
+
+
+def normalize_allowed_file_types() -> list[str]:
+    raw_value = settings.allowed_file_types
+    if isinstance(raw_value, str):
+        values = [item.strip() for item in raw_value.split(",")]
+    elif isinstance(raw_value, (list, tuple, set)):
+        values = [str(item).strip() for item in raw_value]
+    else:
+        values = []
+    normalized = [item.lower() for item in values if item]
+    return normalized or ["*"]
+
+
+def _extension_of(file_name: str) -> str:
+    return Path(file_name or "").suffix.lower()
+
+
+def _match_allow_rule(rule: str, file_name: str, content_type: str) -> bool:
+    if rule in {"*", "*/*"}:
+        return True
+    if "/" in rule:
+        return fnmatchcase(content_type, rule)
+    extension = rule if rule.startswith(".") else f".{rule}"
+    return file_name.endswith(extension)
+
+
+def is_type_allowed(file_name: str, content_type: Optional[str] = None) -> bool:
+    allowed = normalize_allowed_file_types()
+    if any(rule in {"*", "*/*"} for rule in allowed):
+        return True
+    normalized_name = (file_name or "").strip().lower()
+    normalized_content_type = (content_type or "").strip().lower()
+    return any(
+        _match_allow_rule(rule, normalized_name, normalized_content_type)
+        for rule in allowed
+    )
+
+
+def detect_file_kind(header: bytes) -> Optional[FileKind]:
+    if not header:
+        return None
+
+    if len(header) >= 12 and header.startswith(b"RIFF") and header[8:12] == b"WEBP":
+        return next(kind for kind in FILE_KINDS if kind.name == "webp")
+
+    if len(header) >= 12 and header[4:8] == b"ftyp":
+        return next(kind for kind in FILE_KINDS if kind.name == "mp4")
+
+    candidates: list[tuple[int, FileKind]] = []
+    for kind in FILE_KINDS:
+        for signature in kind.signatures:
+            if signature and header.startswith(signature):
+                candidates.append((len(signature), kind))
+    if not candidates:
+        return None
+    candidates.sort(key=lambda item: item[0], reverse=True)
+    return candidates[0][1]
+
+
+def validate_file_type(file_name: str, content_type: Optional[str] = None) -> None:
+    if not is_type_allowed(file_name, content_type):
+        raise HTTPException(status_code=403, detail="不允许上传该类型文件")
+
+
+def _kind_matches_ext(kind: FileKind, extension: str) -> bool:
+    return extension in kind.extensions
+
+
+def _kind_matches_mime(kind: FileKind, mime: str) -> bool:
+    return mime in kind.mimes
+
+
+def validate_file_magic(
+    file_name: str,
+    content_type: Optional[str],
+    header: Optional[bytes],
+) -> None:
+    """白名单通过后，用 magic bytes 防止扩展名 / MIME 伪造。"""
+    validate_file_type(file_name, content_type)
+    if not header:
+        return
+
+    claimed_ext = _extension_of(file_name)
+    claimed_mime = (content_type or "").strip().lower()
+    detected = detect_file_kind(header)
+
+    if claimed_ext in KNOWN_EXTENSIONS:
+        if detected is None or not _kind_matches_ext(detected, claimed_ext):
+            raise HTTPException(
+                status_code=403,
+                detail="文件内容与扩展名不匹配，疑似伪造类型",
+            )
+
+    if claimed_mime and any(claimed_mime in kind.mimes for kind in FILE_KINDS):
+        if detected is None or not _kind_matches_mime(detected, claimed_mime):
+            raise HTTPException(
+                status_code=403,
+                detail="文件内容与 Content-Type 不匹配，疑似伪造类型",
+            )
+
+    allowed = normalize_allowed_file_types()
+    if detected and not any(rule in {"*", "*/*"} for rule in allowed):
+        allowed_by_detected = any(
+            is_type_allowed(f"file{ext}", mime)
+            for ext in detected.extensions
+            for mime in (detected.mimes or (None,))
+        )
+        if not allowed_by_detected:
+            raise HTTPException(status_code=403, detail="不允许上传该类型文件")
+
+
+async def read_upload_header(file: UploadFile, size: int = 64) -> bytes:
+    await file.seek(0)
+    header = await file.read(size)
+    await file.seek(0)
+    return header or b""
+
+
+async def validate_upload_file(file: UploadFile) -> None:
+    header = await read_upload_header(file)
+    validate_file_magic(file.filename or "", file.content_type, header)
+
+
+def validate_header_bytes(
+    file_name: str, content_type: Optional[str], header: bytes
+) -> None:
+    validate_file_magic(file_name, content_type, header)

--- a/apps/base/utils.py
+++ b/apps/base/utils.py
@@ -136,4 +136,5 @@ ip_limit = {
     "error": IPRateLimit(count=settings.errorCount, minutes=settings.errorMinute),
     "metadata": IPRateLimit(count=settings.errorCount, minutes=settings.errorMinute),
     "upload": IPRateLimit(count=settings.uploadCount, minutes=settings.uploadMinute),
+    "login": IPRateLimit(count=settings.loginCount, minutes=settings.loginMinute),
 }

--- a/apps/base/views.py
+++ b/apps/base/views.py
@@ -1,5 +1,4 @@
 import datetime
-from fnmatch import fnmatchcase
 import hashlib
 import os
 import uuid
@@ -23,6 +22,7 @@ from apps.base.schemas import (
     CompleteUploadModel,
     PresignUploadInitRequest,
 )
+from apps.base.file_validation import validate_file_type, validate_upload_file, validate_header_bytes
 from apps.base.utils import (
     get_expire_info,
     get_file_path_name,
@@ -106,36 +106,6 @@ async def validate_file_size(file: UploadFile, max_size: int) -> int:
     return size
 
 
-def normalize_allowed_file_types() -> list[str]:
-    raw_value = settings.allowed_file_types
-    if isinstance(raw_value, str):
-        values = raw_value.replace(";", ",").split(",")
-    elif isinstance(raw_value, (list, tuple, set)):
-        values = raw_value
-    else:
-        values = []
-
-    allowed = [str(item).strip().lower() for item in values if str(item).strip()]
-    return allowed or ["*"]
-
-
-def validate_file_type(file_name: str, content_type: Optional[str] = None) -> None:
-    allowed = normalize_allowed_file_types()
-    if "*" in allowed or "*/*" in allowed:
-        return
-
-    normalized_name = file_name.strip().lower()
-    normalized_content_type = (content_type or "").strip().lower()
-
-    for rule in allowed:
-        if "/" in rule and fnmatchcase(normalized_content_type, rule):
-            return
-
-        extension = rule if rule.startswith(".") else f".{rule}"
-        if normalized_name.endswith(extension):
-            return
-
-    raise HTTPException(status_code=403, detail="不允许上传该类型文件")
 
 
 async def create_file_code(code, **kwargs):
@@ -188,7 +158,7 @@ async def share_file(
     ip: str = Depends(ip_limit["upload"]),
 ):
     file_size = await validate_file_size(file, settings.uploadSize)
-    validate_file_type(file.filename or "", file.content_type)
+    await validate_upload_file(file)
     validate_expire_style(expire_style)
     path, suffix, prefix, uuid_file_name, save_path = await get_file_path_name(file)
     reservation_token = f"file:{uuid.uuid4().hex}"
@@ -549,6 +519,8 @@ async def upload_chunk(
 
     # 读取分片数据并计算哈希
     chunk_data = await chunk.read()
+    if chunk_index == 0:
+        validate_header_bytes(chunk_info.file_name, None, chunk_data[:64])
     chunk_size = len(chunk_data)
 
     # 校验分片大小不超过声明的 chunk_size
@@ -844,6 +816,7 @@ async def presign_upload_proxy(
     )
 
     file_size = await validate_file_size(file, settings.uploadSize)
+    await validate_upload_file(file)
     if abs(file_size - session.file_size) > 1024:
         raise HTTPException(400, "文件大小与声明不符")
 

--- a/core/config.py
+++ b/core/config.py
@@ -19,6 +19,8 @@ SETUP_CONFIG_FIELDS = {
     "enableChunk",
     "errorCount",
     "errorMinute",
+    "loginCount",
+    "loginMinute",
     "expireStyle",
     "max_save_seconds",
     "name",
@@ -68,6 +70,8 @@ def _sync_ip_limits() -> None:
     ip_limit["metadata"].count = settings.errorCount
     ip_limit["upload"].minutes = settings.uploadMinute
     ip_limit["upload"].count = settings.uploadCount
+    ip_limit["login"].minutes = settings.loginMinute
+    ip_limit["login"].count = settings.loginCount
 
 
 async def refresh_settings() -> None:

--- a/core/settings.py
+++ b/core/settings.py
@@ -76,6 +76,8 @@ DEFAULT_CONFIG = {
     "themesSelect": "themes/2024",
     "errorMinute": 1,
     "errorCount": 10,
+    "loginCount": 5,
+    "loginMinute": 15,
     "serverWorkers": 1,
     "serverHost": "0.0.0.0",
     "serverPort": 12345,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3"
 services:
   file-code-box:
     image: lanol/filecodebox:2.5.2 # x-release-please-version
+    user: "1000:1000"
     volumes:
       - fcb-data:/app/data:rw
     restart: unless-stopped

--- a/main.py
+++ b/main.py
@@ -181,6 +181,12 @@ def parse_setup_options(data: dict) -> dict:
         "errorMinute": parse_int_field(
             data, "errorMinute", DEFAULT_CONFIG["errorMinute"], "取件错误检测窗口", 1
         ),
+        "loginCount": parse_int_field(
+            data, "loginCount", DEFAULT_CONFIG["loginCount"], "登录失败次数限制", 1
+        ),
+        "loginMinute": parse_int_field(
+            data, "loginMinute", DEFAULT_CONFIG["loginMinute"], "登录失败检测窗口", 1
+        ),
         "expireStyle": expire_styles,
         "max_save_seconds": save_time_value * SAVE_TIME_UNITS[save_time_unit],
         "openUpload": int(normalize_bool_field(data, "openUpload", True)),
@@ -227,6 +233,12 @@ def build_setup_page(error: str = "", form: dict | None = None) -> str:
     )
     error_count = html.escape(
         get_form_value(form, "errorCount", str(DEFAULT_CONFIG["errorCount"]))
+    )
+    login_minute = html.escape(
+        get_form_value(form, "loginMinute", str(DEFAULT_CONFIG["loginMinute"]))
+    )
+    login_count = html.escape(
+        get_form_value(form, "loginCount", str(DEFAULT_CONFIG["loginCount"]))
     )
     open_upload_checked = (
         " checked" if normalize_bool_field(form, "openUpload", True) else ""
@@ -576,6 +588,12 @@ def build_setup_page(error: str = "", form: dict | None = None) -> str:
             <input name="errorMinute" type="number" min="1" value="{error_minute}" aria-label="取件错误检测窗口分钟" required>
           </div>
 
+          <label for="loginCount">管理员登录失败频率 <span class="compact-help">次数 / 分钟</span></label>
+          <div class="row">
+            <input id="loginCount" name="loginCount" type="number" min="1" value="{login_count}" required>
+            <input name="loginMinute" type="number" min="1" value="{login_minute}" aria-label="登录失败检测窗口分钟" required>
+          </div>
+
           <label for="save_time_value">最长保存时间</label>
           <div class="row">
             <input id="save_time_value" name="save_time_value" type="number" min="0" value="{save_time_value}" required>
@@ -744,6 +762,8 @@ async def load_config():
     ip_limit["error"].count = settings.errorCount
     ip_limit["upload"].minutes = settings.uploadMinute
     ip_limit["upload"].count = settings.uploadCount
+    ip_limit["login"].minutes = settings.loginMinute
+    ip_limit["login"].count = settings.loginCount
 
 app = FastAPI(lifespan=lifespan, version=APP_VERSION)
 

--- a/tests/test_admin_security.py
+++ b/tests/test_admin_security.py
@@ -73,6 +73,8 @@ class SetupOptionTests(unittest.TestCase):
                 "uploadMinute": "2",
                 "errorCount": "5",
                 "errorMinute": "1",
+                "loginCount": "4",
+                "loginMinute": "20",
                 "openUpload": ["0", "1"],
                 "enableChunk": "0",
                 "code_generate_type": "secret",
@@ -87,6 +89,8 @@ class SetupOptionTests(unittest.TestCase):
         self.assertEqual(options["uploadMinute"], 2)
         self.assertEqual(options["errorCount"], 5)
         self.assertEqual(options["errorMinute"], 1)
+        self.assertEqual(options["loginCount"], 4)
+        self.assertEqual(options["loginMinute"], 20)
         self.assertEqual(options["openUpload"], 1)
         self.assertEqual(options["enableChunk"], 0)
         self.assertEqual(options["code_generate_type"], "secret")

--- a/tests/test_security_gaps.py
+++ b/tests/test_security_gaps.py
@@ -1,0 +1,103 @@
+import asyncio
+import unittest
+from pathlib import Path
+
+from fastapi import HTTPException
+
+from apps.admin import views as admin_views
+from apps.admin.schemas import LoginData
+from apps.base.dependencies import IPRateLimit
+from apps.base.file_validation import detect_file_kind, validate_file_magic, validate_file_type
+from apps.base.utils import ip_limit
+from core.settings import settings
+from core.utils import hash_password
+
+
+class SettingsOverrideMixin:
+    def setUp(self):
+        self._original_user_config = dict(settings.user_config)
+
+    def tearDown(self):
+        settings.user_config = self._original_user_config
+
+
+class MagicBytesTests(SettingsOverrideMixin, unittest.TestCase):
+    def test_detects_common_signatures(self):
+        self.assertEqual(detect_file_kind(b"\x89PNG\r\n\x1a\nxxxx").name, "png")
+        self.assertEqual(detect_file_kind(b"\xff\xd8\xff\xe0xxxx").name, "jpg")
+        self.assertEqual(detect_file_kind(b"%PDF-1.7").name, "pdf")
+        self.assertEqual(detect_file_kind(b"PK\x03\x04xxxx").name, "zip")
+        self.assertEqual(detect_file_kind(b"RIFF\x00\x00\x00\x00WEBPxxxx").name, "webp")
+        self.assertEqual(detect_file_kind(b"\x00\x00\x00\x18ftypmp42").name, "mp4")
+
+    def test_rejects_extension_spoofing(self):
+        settings.allowed_file_types = ["*"]
+        with self.assertRaises(HTTPException) as ctx:
+            validate_file_magic("photo.png", "image/png", b"MZ" + b"\x00" * 20)
+        self.assertEqual(ctx.exception.status_code, 403)
+        self.assertIn("扩展名", ctx.exception.detail)
+
+    def test_rejects_content_type_spoofing(self):
+        settings.allowed_file_types = ["*"]
+        with self.assertRaises(HTTPException) as ctx:
+            validate_file_magic("blob.bin", "image/png", b"MZ" + b"\x00" * 20)
+        self.assertEqual(ctx.exception.status_code, 403)
+
+    def test_accepts_matching_png(self):
+        settings.allowed_file_types = [".png", "image/*"]
+        validate_file_magic("a.png", "image/png", b"\x89PNG\r\n\x1a\nxxxx")
+
+    def test_whitelist_still_enforced(self):
+        settings.allowed_file_types = [".png"]
+        with self.assertRaises(HTTPException):
+            validate_file_type("a.exe", "application/x-msdownload")
+
+
+class LoginRateLimitTests(SettingsOverrideMixin, unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        settings.admin_token = hash_password("correct-password-123")
+        settings.jwt_secret = "j" * 48
+        settings.loginCount = 3
+        settings.loginMinute = 15
+        self._original_login_limiter = ip_limit["login"]
+        ip_limit["login"] = IPRateLimit(count=3, minutes=15)
+
+    def tearDown(self):
+        ip_limit["login"] = self._original_login_limiter
+        super().tearDown()
+
+    def test_failed_logins_are_rate_limited(self):
+        async def attempt(password: str):
+            return await admin_views.login(
+                data=LoginData(password=password), ip="203.0.113.10"
+            )
+
+        for _ in range(3):
+            with self.assertRaises(HTTPException) as ctx:
+                asyncio.run(attempt("wrong-password"))
+            self.assertEqual(ctx.exception.status_code, 401)
+
+        self.assertFalse(ip_limit["login"].check_ip("203.0.113.10"))
+
+    def test_successful_login_does_not_consume_failure_quota(self):
+        result = asyncio.run(
+            admin_views.login(
+                data=LoginData(password="correct-password-123"), ip="198.51.100.8"
+            )
+        )
+        self.assertIn("token", result.detail)
+        self.assertTrue(ip_limit["login"].check_ip("198.51.100.8"))
+
+
+class DockerNonRootTests(unittest.TestCase):
+    def test_dockerfile_runs_as_non_root_user(self):
+        text = Path("Dockerfile").read_text()
+        self.assertIn("USER appuser", text)
+        self.assertIn("--uid 1000", text)
+        compose = Path("docker-compose.yml").read_text()
+        self.assertIn('user: "1000:1000"', compose)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
补齐先前审计中 3 个未落地项：

1. **magic bytes 深度校验**：新增 `apps/base/file_validation.py`，在普通上传 / 分片首片 / 预签名代理上传中校验内容与扩展名、Content-Type，防止伪造
2. **管理员登录防爆破**：新增可配置 `loginCount` / `loginMinute`（默认 5 次 / 15 分钟），失败计入 IP 限流
3. **Docker 非 root**：镜像创建 `appuser (uid=1000)` 并以 `USER appuser` 运行；compose 同步 `user: "1000:1000"`

## Test plan
- [x] `python3 -m pytest tests/test_security_gaps.py tests/test_issue_465_file_type.py tests/test_admin_security.py tests/test_security_hardening.py tests/test_pr494_security_patches.py -q`
- [x] 上传扩展名 `.png` 但内容为 PE/`MZ` 应被拒绝
- [x] 连续错误登录超过阈值后返回 423
- [x] 容器进程用户为 `appuser` / uid 1000