### PR TITLE
fix: run Docker as root for volume compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,14 +63,7 @@ RUN apt-get update \
  && apt-get upgrade -y --no-install-recommends \
  && rm -rf /var/lib/apt/lists/* \
  && pip install --no-cache-dir -r requirements.txt \
- && pip cache purge || true \
- && groupadd --system --gid 1000 appuser \
- && useradd --system --uid 1000 --gid appuser --create-home --home-dir /home/appuser --shell /usr/sbin/nologin appuser \
- && mkdir -p /app/data \
- && chown -R appuser:appuser /app
-
-# 非 root 运行，降低容器逃逸后的主机影响面
-USER appuser
+ && pip cache purge || true
 
 # 环境变量配置
 ENV HOST="0.0.0.0" \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ version: "3"
 services:
   file-code-box:
     image: lanol/filecodebox:2.5.3 # x-release-please-version
-    user: "1000:1000"
     volumes:
       - fcb-data:/app/data:rw
     restart: unless-stopped

--- a/tests/test_security_gaps.py
+++ b/tests/test_security_gaps.py
@@ -90,13 +90,13 @@ class LoginRateLimitTests(SettingsOverrideMixin, unittest.TestCase):
         self.assertTrue(ip_limit["login"].check_ip("198.51.100.8"))
 
 
-class DockerNonRootTests(unittest.TestCase):
-    def test_dockerfile_runs_as_non_root_user(self):
+class DockerRuntimeUserTests(unittest.TestCase):
+    def test_dockerfile_defaults_to_root_for_volume_compatibility(self):
+        # 默认 root：兼容已有 data 卷权限；如需非 root 可由编排层自行指定 user
         text = Path("Dockerfile").read_text()
-        self.assertIn("USER appuser", text)
-        self.assertIn("--uid 1000", text)
+        self.assertNotIn("USER appuser", text)
         compose = Path("docker-compose.yml").read_text()
-        self.assertIn('user: "1000:1000"', compose)
+        self.assertNotIn('user: "1000:1000"', compose)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
撤销容器非 root 运行，恢复默认 root：

- `Dockerfile` 去掉 `appuser` / `USER appuser`
- `docker-compose.yml` 去掉 `user: \"1000:1000\"`
- 更新对应测试

原因：已有 Docker data 卷多为 root 属主，非 root 会导致数据库/上传写失败，升级成本高。

## Test plan
- [x] `python3 -m pytest tests/test_security_gaps.py -q`
- [ ] 旧 data 卷无需 chown 即可正常读写