### PR TITLE
fix: sanitize chunk upload file_name to prevent path traversal

### DIFF
--- a/apps/base/utils.py
+++ b/apps/base/utils.py
@@ -43,6 +43,7 @@ async def get_chunk_file_path_name(
 ) -> Tuple[str, str, str, str, str]:
     today = await get_now()
     storage_path = settings.storage_path.strip("/")
+    file_name = await sanitize_filename(unquote(file_name or ""))
     base_path = f"share/data/{today.strftime('%Y/%m/%d')}/{upload_id}"
     path = f"{storage_path}/{base_path}" if storage_path else base_path
     prefix, suffix = os.path.splitext(file_name)

--- a/core/storage.py
+++ b/core/storage.py
@@ -116,6 +116,8 @@ class SystemFileStorage(FileStorageInterface):
         """将相对路径解析到数据根目录内，阻止路径穿越。"""
         root = self.root_path.resolve()
         raw = str(relative_path or "").replace("\\", "/").lstrip("/")
+        if any(part == ".." for part in raw.split("/")):
+            raise ValueError("非法文件路径")
         candidate = (root / raw).resolve()
         try:
             candidate.relative_to(root)

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -10,6 +10,7 @@ from fastapi import HTTPException
 from apps.admin import dependencies as admin_dependencies
 from apps.admin.dependencies import create_token, verify_token
 from apps.admin.services import LocalFileClass
+from apps.base.utils import get_chunk_file_path_name
 from core.settings import data_root, settings
 from core.storage import SystemFileStorage
 from core.utils import hash_password, verify_password
@@ -71,9 +72,42 @@ class SystemStoragePathTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.storage._resolve_safe_path("../etc/passwd")
 
+    def test_resolve_safe_path_blocks_internal_dotdot(self):
+        with self.assertRaises(ValueError):
+            self.storage._resolve_safe_path("share/data/2026/08/29/x/../../../../../../filecodebox.db")
+
+    def test_resolve_safe_path_blocks_windows_dotdot(self):
+        with self.assertRaises(ValueError):
+            self.storage._resolve_safe_path("share\\data\\..\\..\\filecodebox.db")
+
     def test_resolve_safe_path_allows_nested(self):
         target = self.storage._resolve_safe_path("share/data/a/b.txt")
         self.assertTrue(str(target).startswith(str(Path(self._tmpdir.name).resolve())))
+
+
+class ChunkFileNameSanitizeTests(unittest.TestCase):
+    def test_chunk_file_path_name_strips_traversal(self):
+        path, _, _, filename, save_path = asyncio.run(
+            get_chunk_file_path_name("../../../../../../filecodebox.db", "a" * 32)
+        )
+        self.assertNotIn("..", save_path)
+        self.assertEqual(filename, "filecodebox.db")
+        self.assertEqual(save_path, f"{path}/filecodebox.db")
+        self.assertIn("a" * 32, path)
+
+    def test_chunk_file_path_name_strips_windows_traversal(self):
+        _, _, _, filename, save_path = asyncio.run(
+            get_chunk_file_path_name("..\\..\\..\\..\\..\\..\\evil.bin", "b" * 32)
+        )
+        self.assertNotIn("..", save_path)
+        self.assertEqual(filename, "evil.bin")
+
+    def test_chunk_file_path_name_keeps_normal_name(self):
+        _, _, _, filename, save_path = asyncio.run(
+            get_chunk_file_path_name("safe.txt", "c" * 32)
+        )
+        self.assertEqual(filename, "safe.txt")
+        self.assertTrue(save_path.endswith("/safe.txt"))
 
 
 class AdminJwtUrlSafeTests(unittest.TestCase):


### PR DESCRIPTION
## 问题
分片上传 `POST /chunk/upload/init/` 的 `file_name` 未做清洗，直接拼进 `save_path`。
攻击者可使用 `../../` 逃逸出本次 `upload_id` 会话目录，在 `data/` 内任意写文件；在 Linux/Docker 下可覆盖 `data/filecodebox.db`，导致数据库损坏 / 管理员接管 / 服务无法启动（DoS）。

此前 `#496` 的 `_resolve_safe_path` 只保证路径不越出整个 `data/` 根目录，**未**限制在本次上传会话目录内，因此该路径穿越仍可用。

## 修复
1. **`apps/base/utils.py`**：`get_chunk_file_path_name` 与普通上传一致，先 `sanitize_filename` 再拼接路径
2. **`core/storage.py`**：`_resolve_safe_path` 额外拒绝任何 `..` 路径段，防止升级前已入库的恶意 `save_path` 仍被使用
3. **`tests/test_security_hardening.py`**：补充 5 个回归测试（Linux/Windows 风格穿越 + 正常文件名）

## 测试
- `python tests/test_security_hardening.py` 全部通过
- 端到端：带 `../../` 的 `file_name` 会被清洗，文件仅落在会话目录内，无法写到 `data/` 根或覆盖数据库