### PR TITLE
fix: harden chunk upload filename metadata

### DIFF
--- a/apps/base/utils.py
+++ b/apps/base/utils.py
@@ -43,6 +43,7 @@ async def get_chunk_file_path_name(
 ) -> Tuple[str, str, str, str, str]:
     today = await get_now()
     storage_path = settings.storage_path.strip("/")
+    file_name = await sanitize_filename(unquote(file_name or ""))
     base_path = f"share/data/{today.strftime('%Y/%m/%d')}/{upload_id}"
     path = f"{storage_path}/{base_path}" if storage_path else base_path
     prefix, suffix = os.path.splitext(file_name)

--- a/apps/base/views.py
+++ b/apps/base/views.py
@@ -393,7 +393,8 @@ async def parse_complete_upload(request: Request) -> CompleteUploadModel:
 
 @chunk_api.post("/upload/init/", dependencies=[Depends(share_required_login)])
 async def init_chunk_upload(data: InitChunkUploadModel = Depends(parse_init_chunk_upload)):
-    validate_file_type(data.file_name)
+    safe_file_name = await sanitize_filename(unquote(data.file_name or ""))
+    validate_file_type(safe_file_name)
     # 服务端校验：根据 total_chunks * chunk_size 计算理论最大上传量
     total_chunks = (data.file_size + data.chunk_size - 1) // data.chunk_size
     max_possible_size = total_chunks * data.chunk_size
@@ -423,7 +424,7 @@ async def init_chunk_upload(data: InitChunkUploadModel = Depends(parse_init_chun
         chunk_hash=data.file_hash,
         chunk_index=-1,
         file_size=data.file_size,
-        file_name=data.file_name,
+        file_name=safe_file_name,
     ).first()
 
     if existing_session:
@@ -459,7 +460,9 @@ async def init_chunk_upload(data: InitChunkUploadModel = Depends(parse_init_chun
     await reserve_storage(
         reservation_token, data.file_size, ttl_seconds=chunk_expire_seconds
     )
-    _, _, _, _, save_path = await get_chunk_file_path_name(data.file_name, upload_id)
+    _, _, _, safe_file_name, save_path = await get_chunk_file_path_name(
+        data.file_name, upload_id
+    )
     try:
         await UploadChunk.create(
             upload_id=upload_id,
@@ -468,7 +471,7 @@ async def init_chunk_upload(data: InitChunkUploadModel = Depends(parse_init_chun
             file_size=data.file_size,
             chunk_size=data.chunk_size,
             chunk_hash=data.file_hash,
-            file_name=data.file_name,
+            file_name=safe_file_name,
             save_path=save_path,
         )
     except Exception:
@@ -670,7 +673,8 @@ async def complete_upload(
 
     save_path = chunk_info.save_path
     path = os.path.dirname(save_path) if save_path else ""
-    prefix, suffix = os.path.splitext(chunk_info.file_name)
+    safe_file_name = os.path.basename(save_path) if save_path else ""
+    prefix, suffix = os.path.splitext(safe_file_name)
 
     try:
         # 合并文件并计算哈希
@@ -689,7 +693,7 @@ async def complete_upload(
             expired_count=expired_count,
             used_count=used_count,
             file_path=path,
-            uuid_file_name=f"{prefix}{suffix}",
+            uuid_file_name=safe_file_name,
             prefix=prefix,
             suffix=suffix,
         )
@@ -699,7 +703,7 @@ async def complete_upload(
         await UploadChunk.filter(upload_id=upload_id).delete()
         await release_storage(f"chunk:{upload_id}")
         ip_limit["upload"].add_ip(ip)
-        return APIResponse(detail={"code": code, "name": chunk_info.file_name})
+        return APIResponse(detail={"code": code, "name": safe_file_name})
     except ValueError as e:
         raise HTTPException(status.HTTP_400_BAD_REQUEST, detail=str(e))
     except Exception as e:

--- a/core/storage.py
+++ b/core/storage.py
@@ -116,6 +116,8 @@ class SystemFileStorage(FileStorageInterface):
         """将相对路径解析到数据根目录内，阻止路径穿越。"""
         root = self.root_path.resolve()
         raw = str(relative_path or "").replace("\\", "/").lstrip("/")
+        if any(part == ".." for part in raw.split("/")):
+            raise ValueError("非法文件路径")
         candidate = (root / raw).resolve()
         try:
             candidate.relative_to(root)

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -1,4 +1,5 @@
 import asyncio
+from io import BytesIO
 import os
 import tempfile
 import unittest
@@ -6,10 +7,15 @@ from pathlib import Path
 from unittest.mock import patch
 
 from fastapi import HTTPException
+from starlette.datastructures import UploadFile
+from tortoise import Tortoise
 
+from apps.base import views
 from apps.admin import dependencies as admin_dependencies
 from apps.admin.dependencies import create_token, verify_token
 from apps.admin.services import LocalFileClass
+from apps.base.models import FileCodes, UploadChunk
+from apps.base.schemas import CompleteUploadModel, InitChunkUploadModel
 from apps.base.utils import get_chunk_file_path_name
 from core.settings import data_root, settings
 from core.storage import SystemFileStorage
@@ -108,6 +114,95 @@ class ChunkFileNameSanitizeTests(unittest.TestCase):
         )
         self.assertEqual(filename, "safe.txt")
         self.assertTrue(save_path.endswith("/safe.txt"))
+
+
+class ChunkUploadMetadataTests(unittest.TestCase):
+    def test_traversal_filename_remains_downloadable_after_completion(self):
+        asyncio.run(self._run_traversal_upload())
+
+    async def _run_traversal_upload(self):
+        original_config = dict(settings.user_config)
+        tmpdir = tempfile.TemporaryDirectory()
+        try:
+            settings.file_storage = "local"
+            settings.allowed_file_types = ["*"]
+            with patch("core.storage.data_root", Path(tmpdir.name)):
+                await Tortoise.init(
+                    config={
+                        "connections": {
+                            "default": {
+                                "engine": "tortoise.backends.sqlite",
+                                "credentials": {"file_path": ":memory:"},
+                            }
+                        },
+                        "apps": {
+                            "models": {
+                                "models": ["apps.base.models"],
+                                "default_connection": "default",
+                            }
+                        },
+                        "use_tz": False,
+                        "timezone": "Asia/Shanghai",
+                    }
+                )
+                await Tortoise.generate_schemas()
+                try:
+                    raw_name = "../../../../../../filecodebox.db"
+                    payload = b"chunk payload"
+                    init_result = await views.init_chunk_upload(
+                        InitChunkUploadModel(
+                            file_name=raw_name,
+                            file_size=len(payload),
+                            chunk_size=1024,
+                            file_hash="f" * 64,
+                        )
+                    )
+                    upload_id = init_result.detail["upload_id"]
+                    session = await UploadChunk.get(
+                        upload_id=upload_id, chunk_index=-1
+                    )
+                    self.assertEqual(session.file_name, "filecodebox.db")
+                    self.assertNotIn("..", session.save_path)
+
+                    await views.upload_chunk(
+                        upload_id=upload_id,
+                        chunk_index=0,
+                        chunk=UploadFile(
+                            file=BytesIO(payload), filename="filecodebox.db"
+                        ),
+                    )
+
+                    # Simulate a legacy session whose display name was not sanitized.
+                    session.file_name = raw_name
+                    await session.save(update_fields=["file_name"])
+
+                    complete_result = await views.complete_upload(
+                        upload_id=upload_id,
+                        data=CompleteUploadModel(
+                            expire_value=1, expire_style="day"
+                        ),
+                        ip="127.0.0.1",
+                    )
+                    self.assertEqual(complete_result.detail["name"], "filecodebox.db")
+
+                    file_code = await FileCodes.get(code=complete_result.detail["code"])
+                    expected_relative_path = session.save_path
+                    self.assertEqual(
+                        await file_code.get_file_path(), expected_relative_path
+                    )
+                    storage = views.storages[settings.file_storage]()
+                    resolved_path = storage._resolve_safe_path(
+                        await file_code.get_file_path()
+                    )
+                    self.assertEqual(
+                        resolved_path, Path(tmpdir.name).resolve() / expected_relative_path
+                    )
+                    self.assertEqual(resolved_path.read_bytes(), payload)
+                finally:
+                    await Tortoise.close_connections()
+        finally:
+            settings.user_config = original_config
+            tmpdir.cleanup()
 
 
 class AdminJwtUrlSafeTests(unittest.TestCase):

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -10,6 +10,7 @@ from fastapi import HTTPException
 from apps.admin import dependencies as admin_dependencies
 from apps.admin.dependencies import create_token, verify_token
 from apps.admin.services import LocalFileClass
+from apps.base.utils import get_chunk_file_path_name
 from core.settings import data_root, settings
 from core.storage import SystemFileStorage
 from core.utils import hash_password, verify_password
@@ -71,9 +72,42 @@ class SystemStoragePathTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.storage._resolve_safe_path("../etc/passwd")
 
+    def test_resolve_safe_path_blocks_internal_dotdot(self):
+        with self.assertRaises(ValueError):
+            self.storage._resolve_safe_path("share/data/2026/08/29/x/../../../../../../filecodebox.db")
+
+    def test_resolve_safe_path_blocks_windows_dotdot(self):
+        with self.assertRaises(ValueError):
+            self.storage._resolve_safe_path("share\\data\\..\\..\\filecodebox.db")
+
     def test_resolve_safe_path_allows_nested(self):
         target = self.storage._resolve_safe_path("share/data/a/b.txt")
         self.assertTrue(str(target).startswith(str(Path(self._tmpdir.name).resolve())))
+
+
+class ChunkFileNameSanitizeTests(unittest.TestCase):
+    def test_chunk_file_path_name_strips_traversal(self):
+        path, _, _, filename, save_path = asyncio.run(
+            get_chunk_file_path_name("../../../../../../filecodebox.db", "a" * 32)
+        )
+        self.assertNotIn("..", save_path)
+        self.assertEqual(filename, "filecodebox.db")
+        self.assertEqual(save_path, f"{path}/filecodebox.db")
+        self.assertIn("a" * 32, path)
+
+    def test_chunk_file_path_name_strips_windows_traversal(self):
+        _, _, _, filename, save_path = asyncio.run(
+            get_chunk_file_path_name("..\\..\\..\\..\\..\\..\\evil.bin", "b" * 32)
+        )
+        self.assertNotIn("..", save_path)
+        self.assertEqual(filename, "evil.bin")
+
+    def test_chunk_file_path_name_keeps_normal_name(self):
+        _, _, _, filename, save_path = asyncio.run(
+            get_chunk_file_path_name("safe.txt", "c" * 32)
+        )
+        self.assertEqual(filename, "safe.txt")
+        self.assertTrue(save_path.endswith("/safe.txt"))
 
 
 class AdminJwtUrlSafeTests(unittest.TestCase):


### PR DESCRIPTION
This PR carries the path traversal hardening from #505 and completes the related filename metadata fix.

Changes:
- persist the sanitized filename in UploadChunk and use it for resume matching;
- derive FileCodes filename metadata from the safe save_path, including for legacy sessions;
- add an init -> chunk upload -> complete regression test for traversal filenames.

The original #505 commit is included in this branch.